### PR TITLE
Update x-mind-viewer-view.ts

### DIFF
--- a/src/core/x-mind-viewer-view.ts
+++ b/src/core/x-mind-viewer-view.ts
@@ -1,12 +1,4 @@
-import {
-    App,
-    MarkdownView,
-    TextFileView,
-    WorkspaceLeaf,
-    FileView,
-    TFile,
-    IconName,
-} from 'obsidian';
+import { App, FileView, IconName, TFile, WorkspaceLeaf } from 'obsidian';
 import { XMindViewerPlugin } from './x-mind-viewer-plugin';
 import { XMindEmbedViewer } from 'xmind-embed-viewer';
 
@@ -15,6 +7,8 @@ const viewType = 'xmind-viewer';
 export class XMindViewerView extends FileView {
     plugin: XMindViewerPlugin;
     styles: Partial<CSSStyleDeclaration>;
+    viewer?: XMindEmbedViewer;
+
     constructor(leaf: WorkspaceLeaf, app: App, plugin: XMindViewerPlugin) {
         super(leaf);
         this.app = app;
@@ -43,19 +37,17 @@ export class XMindViewerView extends FileView {
 
     async onLoadFile(file: TFile): Promise<void> {
         const binary = await this.app.vault.readBinary(file);
-        
-        // Clear any previous content
-        this.contentEl.empty();
-        
-        // Wait for the viewer to be ready
-        await new Promise<void>((resolve) => {
-            new XMindEmbedViewer({
-                el: this.contentEl,
-                file: binary,
-                region: 'global',
-                styles: this.styles,
-                onInit: () => resolve()
-            });
+
+        if (this.viewer) {
+            this.viewer.load(binary);
+            return;
+        }
+
+        this.viewer = new XMindEmbedViewer({
+            el: this.contentEl,
+            file: binary,
+            region: 'global',
+            styles: this.styles,
         });
     }
 }

--- a/src/core/x-mind-viewer-view.ts
+++ b/src/core/x-mind-viewer-view.ts
@@ -43,11 +43,19 @@ export class XMindViewerView extends FileView {
 
     async onLoadFile(file: TFile): Promise<void> {
         const binary = await this.app.vault.readBinary(file);
-        new XMindEmbedViewer({
-            el: this.contentEl,
-            file: binary,
-            region: 'global',
-            styles: this.styles,
+        
+        // Clear any previous content
+        this.contentEl.empty();
+        
+        // Wait for the viewer to be ready
+        await new Promise<void>((resolve) => {
+            new XMindEmbedViewer({
+                el: this.contentEl,
+                file: binary,
+                region: 'global',
+                styles: this.styles,
+                onInit: () => resolve()
+            });
         });
     }
 }


### PR DESCRIPTION
Hello!

I don't have an easy way to test this, but this should be all that is needed to fix #4 where the file is not rendered correctly. This just waits for the `XMindEmbedViewer` to be ready and also clears the content buffer, which will clear memory as the user switches between context of different `.xmind` files.

You could also try to convert the binary data from the file to a `Blob` first, like this:

```typescript
async onLoadFile(file: TFile): Promise<void> {
    const binary = await this.app.vault.readBinary(file);
    const blob = new Blob([binary], { type: 'application/xmind' });
    
    this.contentEl.empty();
    
    await new Promise<void>((resolve) => {
        new XMindEmbedViewer({
            el: this.contentEl,
            file: blob,
            region: 'global', 
            styles: this.styles,
            onInit: () => resolve()
        });
    });
}
```

I'm a user of both Obsidian and of XMind, so I'm hoping some of this helps. Thank you!

-Rob